### PR TITLE
Fix minimum version of JSON::PP prereq

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -11,7 +11,7 @@ WriteMakefile(
         'HTTP::Tiny' => 0.012,
         'Module::CoreList' => 0,
         'version' => 0,
-        'JSON::PP' => 0,
+        'JSON::PP' => 2.01,
     },
     LICENSE => 'perl',
     EXE_FILES => [ 'bin/pm-uninstall' ],


### PR DESCRIPTION
Tested on a custom compiled perl 5.10.1 and this change to the Makefile.PL ensures that JSON::PP is upgraded appropriately via the dependency chain. Fixes issue #2.
