### PR TITLE
realpath has to be applied to both local_lib and filename

### DIFF
--- a/lib/App/pmuninstall.pm
+++ b/lib/App/pmuninstall.pm
@@ -309,6 +309,7 @@ sub is_local_lib {
 
     my $local_lib_base = quotemeta File::Spec->catfile(Cwd::realpath($self->{local_lib}));
     $file = File::Spec->catfile($file);
+    $file = Cwd::realpath($file);
 
     return $file =~ /^$local_lib_base/ ? 1 : 0;
 }


### PR DESCRIPTION
Hi,
when using local-lib with a directory name which contains ".." uninstall doesn't work.
Here is an example:

```
$ cpanm -l /tmp/foo/../bar/ URI::Find
...
$ pm-uninstall -l /tmp/foo/../bar/ -v URI::Find
--> Working on URI::Find
URI::Find is included in the distribution URI-Find and contains:


Are you sure you want to uninstall URI-Find? [y] 
```

As a result, the .packlist is removed, but not the URI/Find.pm file and others.
