### PR TITLE
Fix path processing: PERL5LIB and realpath

### DIFF
--- a/lib/App/pmuninstall.pm
+++ b/lib/App/pmuninstall.pm
@@ -336,6 +336,7 @@ sub setup_local_lib {
 
     local $SIG{__WARN__} = sub { }; # catch 'Attempting to write ...'
     $self->{inc} = [
+        grep { defined }
         map { Cwd::realpath($_) }
             @{$self->build_active_perl5lib($self->{local_lib}, $self->{self_contained})}
     ];

--- a/lib/App/pmuninstall.pm
+++ b/lib/App/pmuninstall.pm
@@ -347,7 +347,7 @@ sub build_active_perl5lib {
     my $perl5libs = [
         $self->install_base_arch_path($path),
         $self->install_base_perl_path($path),
-        $interpolate && $ENV{PERL5LIB} ? $ENV{PERL5LIB} : (),
+        $interpolate && $ENV{PERL5LIB} ? split(/\Q$Config{path_sep}\E/, $ENV{PERL5LIB}) : (),
     ];
     return $perl5libs;
 }


### PR DESCRIPTION
- Need to split `$ENV{PERL5LIB}` on path separator

  Since `$ENV{PERL5LIB}` can contain a list of directories.

- Only keep valid values from `realpath()`

  Errors from `realpath` are not captured and thus can propagate `undef` when
  processing the `inc` list.
